### PR TITLE
Updated message dependencies, goal position dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   geographic_msgs
   sensor_msgs
   mavros_msgs
+  task_master
 
 )
 
@@ -82,6 +83,7 @@ find_package(catkin REQUIRED COMPONENTS
    prop_mapper
    geographic_msgs
    sensor_msgs
+   task_master
  )
 
 ################################################

--- a/msg/Task.msg
+++ b/msg/Task.msg
@@ -1,7 +1,0 @@
-uint8 TASK_NOT_SET = 0
-uint8 NAVIGATION_CHANNEL = 1
-uint8 AVOID_CROWDS = 2
-uint8 DOCKING = 3
-uint8 SPEED_RUN = 4
-
-uint8 current_task

--- a/msg/TaskGoalPosition.msg
+++ b/msg/TaskGoalPosition.msg
@@ -1,2 +1,0 @@
-Task task
-geometry_msgs/PoseStamped goal_pose

--- a/msg/TaskStatus.msg
+++ b/msg/TaskStatus.msg
@@ -1,8 +1,0 @@
-Task task
-
-uint8 NOT_STARTED = 0
-uint8 IN_PROGRESS = 1
-uint8 FAILED = 2
-uint8 COMPLETE = 3
-
-uint8 status

--- a/src/fake_prop_array.cpp
+++ b/src/fake_prop_array.cpp
@@ -77,13 +77,14 @@ int main(int argc, char** argv) {
     prop_array.props.push_back(red_prop_g2);
     prop_array.props.push_back(green_prop_g2);
 
-    nav_channel::TaskStatus task;
-    task.task.current_task = 1;
+    // Sets task to nav_channel without use of task_master
+    //nav_channel::TaskStatus task;
+    //task.task.current_task = 1;
 
     while (ros::ok())
     {
         pub.publish(prop_array);
-        task_pub.publish(task);
+        //task_pub.publish(task);
         ros::spinOnce();
         loop_rate.sleep();
     }

--- a/src/nav_channel_ctrl.cpp
+++ b/src/nav_channel_ctrl.cpp
@@ -8,6 +8,7 @@
 #include <nav_msgs/Odometry.h>
 #include <cmath>
 #include <iostream>
+#include <geometry_msgs/Point.h>
 
 class NavChannel {
 public:
@@ -48,11 +49,9 @@ public:
         }
     }
 
-    void setDestination(auto midpoint) {
+    void setDestination(geometry_msgs::Point midpoint) {
         // sets goal_pos and then publishes it
-        goal_pos_.x = midpoint.x;
-        goal_pos_.y = midpoint.y;
-        goal_pos_.z = midpoint.z;
+        goal_pos_.point = midpoint;
         // does this set orientation to (0,0,0,0), do we need to grab current orientation and set that to new orientation?
 
         ROS_INFO_STREAM("Midpoint set at " << midpoint.x << ","<< midpoint.y << "," << midpoint.z);
@@ -60,15 +59,10 @@ public:
         task_goal_position_.publish(goal_pos_);
     }
 
-    auto findMidpoint(int gate) {
+    geometry_msgs::Point findMidpoint(int gate) {
         // validates positions of props, then calculates midpoint, and returns
-        // it as PoseStamped
-        struct
-        {
-            float x;
-            float y;
-            float z;
-        } midpoint;
+        // it as Point
+        geometry_msgs::Point midpoint;
         
 
         bool red = false;   // use two booleans to determine if props exist
@@ -200,7 +194,7 @@ private:
                 // if have two good props, ie. red on left, green on right, within 10 feet of each other, then go
 
                 ROS_INFO("Start task.");
-                auto midpoint = findMidpoint(1);
+                geometry_msgs::Point midpoint = findMidpoint(1);
                 ROS_INFO("Found midpoint.");
                 setDestination(midpoint);
                 ROS_INFO("Set midpoint.");
@@ -223,7 +217,7 @@ private:
             case states::find_wp2: {
                 
                 ROS_DEBUG("at gate 1.");
-                auto midpoint = findMidpoint(2);
+                geometry_msgs::Point midpoint = findMidpoint(2);
                 setDestination(midpoint);
 
                 status = states::moving_to_wp2;

--- a/src/nav_channel_ctrl.cpp
+++ b/src/nav_channel_ctrl.cpp
@@ -68,13 +68,20 @@ public:
         prop_mapper::Prop red_prop;
         prop_mapper::Prop green_prop;
         ROS_DEBUG_STREAM("Gate #" << gate);
+        ROS_INFO("fM 1");
 
         for (int i = 0; (!red || !green) || i >= sizeof(props_.props) ; i++) {
+            ROS_INFO("fM 2");
             if (props_.props[i].prop_label == "Red Prop" || props_.props[i].prop_label == "Green Prop") {
+                ROS_INFO("fM 3");
                 double dist_to_gate = sqrt(pow(props_.props[i].vector.x - current_pos_.pose.pose.position.x, 2) + pow(props_.props[i].vector.y - current_pos_.pose.pose.position.y, 2));
+                ROS_INFO_STREAM(gate);
+                ROS_INFO_STREAM(gate_max_dist);
+                ROS_INFO_STREAM(dist_to_gate);
                 if ((gate == 1 && dist_to_gate <= gate_max_dist) || (gate == 2 && dist_to_gate > gate_max_dist)) {
                 // using 8m as roughly 25ft
                 // gate 1 should be within 25ft, gate 2 should be at least 25ft away
+                    ROS_INFO("fM 4");
                     if (props_.props[i].prop_label == "Red Prop") {
                         if (green) {
                             float dist = sqrt(pow(green_prop.vector.x - props_.props[i].vector.x, 2) + pow(green_prop.vector.y - props_.props[i].vector.y, 2));
@@ -107,8 +114,12 @@ public:
                         }
                     }
                 }
+                else {
+                    ROS_INFO("Gate not within max distance.");
+                }
             }
         }
+        ROS_INFO("fM 5");
             
         if (red && green) {
             float red_x = red_prop.vector.x;
@@ -127,6 +138,7 @@ public:
         else {
             ROS_INFO("gates were not found.");
         }
+        ROS_INFO("fM 6");
 
         ROS_DEBUG("returning midpoint.");
 
@@ -171,13 +183,16 @@ private:
         if(msg.task.current_task == task_master::Task::NAVIGATION_CHANNEL) {
             // start task
             task_master::TaskStatus taskStatus;
-            taskStatus.status = task_master::TaskStatus::IN_PROGRESS;
-            task_status_.publish(taskStatus);
 
             switch (status)
             {
             case states::not_started: {
                 ROS_INFO("in not started case.");
+
+                taskStatus.status = task_master::TaskStatus::IN_PROGRESS;
+                taskStatus.task.current_task = task_master::Task::NAVIGATION_CHANNEL;
+                task_status_.publish(taskStatus);
+
                 status = states::find_wp1;
                 }
                 break;
@@ -187,8 +202,9 @@ private:
 
                 ROS_INFO("start task.");
                 geometry_msgs::PoseStamped midpoint = findMidpoint(1);
+                ROS_INFO("found midpoint.");
                 setDestination(midpoint);
-
+                ROS_INFO("set midpoint.");
                 status = states::moving_to_wp1;
                 }
                 break;

--- a/src/nav_channel_ctrl.cpp
+++ b/src/nav_channel_ctrl.cpp
@@ -50,10 +50,12 @@ public:
 
     void setDestination(auto midpoint) {
         // sets goal_pos and then publishes it
-        goal_pos_.goal_pose = midpoint;
+        goal_pos_.x = midpoint.x;
+        goal_pos_.y = midpoint.y;
+        goal_pos_.z = midpoint.z;
         // does this set orientation to (0,0,0,0), do we need to grab current orientation and set that to new orientation?
 
-        ROS_INFO_STREAM("Midpoint set at " << midpoint.pose.position.x << ","<< midpoint.pose.position.y << "," << midpoint.pose.position.z);
+        ROS_INFO_STREAM("Midpoint set at " << midpoint.x << ","<< midpoint.y << "," << midpoint.z);
 
         task_goal_position_.publish(goal_pos_);
     }
@@ -146,8 +148,8 @@ public:
         ROS_DEBUG("travelling...");
         // check to see it we are at the goal (within a set amount of error)
         bool atDestination = false;
-        if (current_pos_.pose.pose.position.x < goal_pos_.goal_pose.pose.position.x+error & current_pos_.pose.pose.position.x > goal_pos_.goal_pose.pose.position.x-error) {
-            if (current_pos_.pose.pose.position.y < goal_pos_.goal_pose.pose.position.y+error & current_pos_.pose.pose.position.y > goal_pos_.goal_pose.pose.position.y-error) {
+        if (current_pos_.pose.pose.position.x < goal_pos_.x+error & current_pos_.pose.pose.position.x > goal_pos_.x-error) {
+            if (current_pos_.pose.pose.position.y < goal_pos_.y+error & current_pos_.pose.pose.position.y > goal_pos_.y-error) {
                 ROS_INFO("Arrived at destination.");
                 atDestination = true;
             }

--- a/src/nav_channel_ctrl.cpp
+++ b/src/nav_channel_ctrl.cpp
@@ -52,6 +52,7 @@ public:
     void setDestination(geometry_msgs::Point midpoint) {
         // sets goal_pos and then publishes it
         goal_pos_.point = midpoint;
+        goal_pos_.task = 1; // sets task to nav_channel for message filtering
         // does this set orientation to (0,0,0,0), do we need to grab current orientation and set that to new orientation?
 
         ROS_INFO_STREAM("Midpoint set at " << midpoint.x << ","<< midpoint.y << "," << midpoint.z);


### PR DESCRIPTION
Replaced nav_channel::Task/TaskStatus/TaskGoalPosition with task_master::Task/TaskStatus/TaskGoalPosition.

Updated TaskGoalPosition to use floats for x, y, and z instead of PoseStamped message.

https://app.asana.com/0/1205704672457617/1205963318337969